### PR TITLE
Feature template notifications tweaks

### DIFF
--- a/src/ui/public/notify/__tests__/notifier.js
+++ b/src/ui/public/notify/__tests__/notifier.js
@@ -11,11 +11,11 @@ describe('Notifier', function () {
   const version = window.__KBN__.version;
   const buildNum = window.__KBN__.buildNum;
   const message = 'Oh, the humanity!';
+  const customText = 'fooMarkup';
   const customParams = {
     title: 'fooTitle',
-    markdown: 'fooMardown',
     lifetime: 10000,
-    customActions:[{
+    actions:[{
       text: 'Cancel',
       callback: sinon.spy()
     }, {
@@ -202,23 +202,23 @@ describe('Notifier', function () {
       expect(notifier.custom).to.be.defined;
     });
     it('properly merges options', function () {
-      const customNotif = notifier.custom(customParams);
+      const customNotif = notifier.custom(customText, customParams);
       expect(customNotif.title).to.equal(customParams.title);
       expect(customNotif.markdown).to.equal(customParams.markdown);
       expect(customNotif.lifetime).to.equal(customParams.lifetime);
     });
     it('gives a default action if none are provided', function () {
-      const noActionParams = _.assign({}, customParams, { customActions: []});
-      const customNotif = notifier.custom(noActionParams);
+      const noActionParams = _.assign({}, customParams, { actions: []});
+      const customNotif = notifier.custom(customText, noActionParams);
       expect(customNotif.actions.length).to.equal(1);
     });
     it('should wrap the callback functions in a close function', function () {
-      const customNotif = notifier.custom(customParams);
-      customNotif.customActions.forEach((action, idx) => {
-        expect(action.callback).not.to.equal(customParams.customActions[idx]);
+      const customNotif = notifier.custom(customText, customParams);
+      customNotif.actions.forEach((action, idx) => {
+        expect(action.callback).not.to.equal(customParams.actions[idx]);
         action.callback();
       });
-      customParams.customActions.forEach(action => {
+      customParams.actions.forEach(action => {
         expect(action.callback.called).to.true;
       });
     });

--- a/src/ui/public/notify/__tests__/notifier.js
+++ b/src/ui/public/notify/__tests__/notifier.js
@@ -198,23 +198,50 @@ describe('Notifier', function () {
   });
 
   describe('#custom', function () {
+    let customNotif;
+
+    beforeEach(() => {
+      customNotif = notifier.custom(customText, customParams);
+    });
+
+    afterEach(() => {
+      customNotif.clear();
+    });
+
     it('has a custom function to make notifications', function () {
       expect(notifier.custom).to.be.defined;
     });
+
     it('properly merges options', function () {
-      const customNotif = notifier.custom(customText, customParams);
-      expect(customNotif.title).to.equal(customParams.title);
-      expect(customNotif.markdown).to.equal(customParams.markdown);
-      expect(customNotif.lifetime).to.equal(customParams.lifetime);
+      expect(customNotif).to.have.property('title', customParams.title);
+      expect(customNotif).to.have.property('lifetime', customParams.lifetime);
+
+      expect(customParams.title).to.be.a('string');
+      expect(customParams.lifetime).to.be.a('number');
     });
+
+    it('sets the content', function () {
+      expect(customNotif).to.have.property('content', `${params.location}: ${customText}`);
+      expect(customNotif.content).to.be.a('string');
+    });
+
+    it('uses custom actions', function () {
+      expect(customNotif).to.have.property('customActions');
+      expect(customNotif.customActions).to.have.length(customParams.actions.length);
+    });
+
     it('gives a default action if none are provided', function () {
-      const noActionParams = _.assign({}, customParams, { actions: []});
-      const customNotif = notifier.custom(customText, noActionParams);
-      expect(customNotif.actions.length).to.equal(1);
+      // destroy the default custom notification, avoid duplicate handling
+      customNotif.clear();
+
+      const noActionParams = _.defaults({ actions: [] }, customParams);
+      customNotif = notifier.custom(customText, noActionParams);
+      expect(customNotif).to.have.property('actions');
+      expect(customNotif.actions).to.have.length(1);
     });
+
     it('should wrap the callback functions in a close function', function () {
-      const customNotif = notifier.custom(customText, customParams);
-      customNotif.actions.forEach((action, idx) => {
+      customNotif.customActions.forEach((action, idx) => {
         expect(action.callback).not.to.equal(customParams.actions[idx]);
         action.callback();
       });
@@ -232,7 +259,7 @@ describe('Notifier', function () {
     });
 
     it('prepends location to message for markdown', function () {
-      expect(notify('banner').markdown).to.equal(params.location + ': ' + message);
+      expect(notify('banner').content).to.equal(params.location + ': ' + message);
     });
 
     it('sets type to "banner"', function () {

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -483,7 +483,6 @@ function createGroupLogger(type, opts) {
 
     if (consoleGroups) {
       if (status) {
-        console.log(status);
         console.groupEnd();
       } else {
         if (opts.open) {

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -402,10 +402,12 @@ Notifier.prototype.banner = function (msg, cb) {
 
 /**
  * Display a custom message
+ * @param  {String} msg
  * @param  {Object} config
+ * @param  {Function} cb
+ *
  * config = {
  *   title: 'Some Title here',
- *   content: 'Some markdown content',
  *   type: 'info',
  *   actions: [{
  *     text: 'next',

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -426,7 +426,12 @@ Notifier.prototype.custom = function (msg, config, cb) {
   }, config);
 
   const hasActions = _.get(mergedConfig, 'actions.length');
-  mergedConfig.actions = (!hasActions) ? ['accept'] : mergedConfig.actions.slice(0, customActionMax);
+  if (!hasActions) {
+    mergedConfig.actions = ['accept'];
+  } else {
+    mergedConfig.customActions = mergedConfig.actions.slice(0, customActionMax);
+    delete mergedConfig.actions;
+  }
 
   return add(mergedConfig, cb);
 };

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -320,8 +320,14 @@ Notifier.prototype._showFatal = function (err) {
  * @param  {Error|String} err
  * @param  {Function} cb
  */
-Notifier.prototype.error = function (err, cb) {
-  return add({
+Notifier.prototype.error = function (err, opts, cb) {
+  const overrideable = ['lifetime', 'icon'];
+  if (_.isFunction(opts)) {
+    cb = opts;
+    opts = {};
+  }
+
+  const config = _.assign({
     type: 'danger',
     content: formatMsg(err, this.from),
     icon: 'warning',
@@ -329,7 +335,8 @@ Notifier.prototype.error = function (err, cb) {
     lifetime: Notifier.config.errorLifetime,
     actions: ['report', 'accept'],
     stack: formatStack(err)
-  }, cb);
+  }, _.pick(opts, overrideable));
+  return add(config, cb);
 };
 
 /**
@@ -337,15 +344,22 @@ Notifier.prototype.error = function (err, cb) {
  * @param  {String} msg
  * @param  {Function} cb
  */
-Notifier.prototype.warning = function (msg, cb) {
-  return add({
+Notifier.prototype.warning = function (msg, opts, cb) {
+  const overrideable = ['lifetime', 'icon'];
+  if (_.isFunction(opts)) {
+    cb = opts;
+    opts = {};
+  }
+
+  const config = _.assign({
     type: 'warning',
     content: formatMsg(msg, this.from),
     icon: 'warning',
     title: 'Warning',
     lifetime: Notifier.config.warningLifetime,
     actions: ['accept']
-  }, cb);
+  }, _.pick(opts, overrideable));
+  return add(config, cb);
 };
 
 /**
@@ -353,15 +367,22 @@ Notifier.prototype.warning = function (msg, cb) {
  * @param  {String} msg
  * @param  {Function} cb
  */
-Notifier.prototype.info = function (msg, cb) {
-  return add({
+Notifier.prototype.info = function (msg, opts, cb) {
+  const overrideable = ['lifetime', 'icon'];
+  if (_.isFunction(opts)) {
+    cb = opts;
+    opts = {};
+  }
+
+  const config = _.assign({
     type: 'info',
     content: formatMsg(msg, this.from),
     icon: 'info-circle',
     title: 'Debug',
     lifetime: Notifier.config.infoLifetime,
     actions: ['accept']
-  }, cb);
+  }, _.pick(opts, overrideable));
+  return add(config, cb);
 };
 
 /**

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -407,7 +407,7 @@ Notifier.prototype.banner = function (msg, cb) {
  *   title: 'Some Title here',
  *   content: 'Some markdown content',
  *   type: 'info',
- *   customActions: [{
+ *   actions: [{
  *     text: 'next',
  *     callback: function() { next(); }
  *   }, {
@@ -416,23 +416,19 @@ Notifier.prototype.banner = function (msg, cb) {
  *   }]
  * }
  */
-Notifier.prototype.custom = function (config) {
+Notifier.prototype.custom = function (msg, config, cb) {
   const customActionMax = 3;
-  const mergedConfig = _.assign({}, {
-    type: 'banner',
-    content: '',
-    lifetime: Notifier.config.bannerLifetime,
+  const mergedConfig = _.assign({
+    type: 'custom',
+    title: 'Notification',
+    content: formatMsg(msg, this.from),
+    lifetime: Notifier.config.infoLifetime,
   }, config);
 
-  const hasActions = _.get(mergedConfig, 'customActions.length') || _.get(mergedConfig, 'actions.length');
-  // Add an ok if there are no actions, so you don't end up with a orphan notification
-  if (!hasActions) {
-    mergedConfig.actions = ['accept'];
-  } else if (mergedConfig.customActions) {
-    mergedConfig.customActions = mergedConfig.customActions.slice(0, customActionMax);
-  }
+  const hasActions = _.get(mergedConfig, 'actions.length');
+  mergedConfig.actions = (!hasActions) ? ['accept'] : mergedConfig.actions.slice(0, customActionMax);
 
-  return add(mergedConfig);
+  return add(mergedConfig, cb);
 };
 
 Notifier.prototype.describeError = formatMsg.describeError;

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -61,7 +61,7 @@ function timerCanceler(notif, cb = _.noop, key) {
 function startNotifTimer(notif, cb) {
   const interval = 1000;
 
-  if (notif.lifetime === Infinity) {
+  if (notif.lifetime === Infinity || notif.lifetime === 0) {
     return;
   }
 

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -70,7 +70,7 @@ function startNotifTimer(notif, cb) {
   notif.timerId = Notifier.config.setInterval(function () {
     notif.timeRemaining -= 1;
 
-    if (notif.timeRemaining === 0) {
+    if (notif.timeRemaining <= 0) {
       closeNotif(notif, cb, 'ignore')();
     }
   }, interval, notif.timeRemaining);

--- a/src/ui/public/notify/notifier.js
+++ b/src/ui/public/notify/notifier.js
@@ -130,12 +130,14 @@ function add(notif, cb) {
 }
 
 function set(opts, cb) {
+  if (!opts.content) {
+    return null;
+  }
+
   if (this._sovereignNotif) {
     this._sovereignNotif.clear();
   }
-  if (!opts.content && !opts.markdown) {
-    return null;
-  }
+
   this._sovereignNotif = add(opts, cb);
   return this._sovereignNotif;
 }
@@ -371,7 +373,7 @@ Notifier.prototype.banner = function (msg, cb) {
   return this.set({
     type: 'banner',
     title: 'Attention',
-    markdown: formatMsg(msg, this.from),
+    content: formatMsg(msg, this.from),
     lifetime: Notifier.config.bannerLifetime,
     actions: ['accept']
   }, cb);
@@ -382,7 +384,7 @@ Notifier.prototype.banner = function (msg, cb) {
  * @param  {Object} config
  * config = {
  *   title: 'Some Title here',
- *   markdown: 'Some markdown content',
+ *   content: 'Some markdown content',
  *   type: 'info',
  *   customActions: [{
  *     text: 'next',
@@ -397,7 +399,7 @@ Notifier.prototype.custom = function (config) {
   const customActionMax = 3;
   const mergedConfig = _.assign({}, {
     type: 'banner',
-    markdown: '',
+    content: '',
     lifetime: Notifier.config.bannerLifetime,
   }, config);
 

--- a/src/ui/public/notify/notify.less
+++ b/src/ui/public/notify/notify.less
@@ -25,7 +25,6 @@
         }
       }
     }
-
   }
 
   .alert {
@@ -47,35 +46,36 @@
     }
   }
 
-    .toast-message {
-      flex: 1 1 auto;
-      .ellipsis();
-      line-height: normal;
+  .toast-message {
+    flex: 1 1 auto;
+    margin-top: 10px;
+    .ellipsis();
+    line-height: normal;
+  }
+
+  .toast-stack {
+    padding-bottom: 10px;
+
+    pre {
+      display: inline-block;
+      width: 100%;
+      margin: 10px 0;
+      word-break: normal;
+      word-wrap: normal;
+      white-space: pre-wrap;
     }
+  }
 
-    .toast-stack {
-      padding-bottom: 10px;
+  .toast-controls {
+    display: flex;
 
-      pre {
-        display: inline-block;
-        width: 100%;
-        margin: 10px 0;
-        word-break: normal;
-        word-wrap: normal;
-        white-space: pre-wrap;
-      }
+    button {
+      flex: 0 0 auto;
+      border: 0;
+      border-radius: 0;
+      padding: 10px 15px;
     }
-
-    .toast-controls {
-      display: flex;
-
-      button {
-        flex: 0 0 auto;
-        border: 0;
-        border-radius: 0;
-        padding: 10px 15px;
-      }
-    }
+  }
 
   // add darkened background to the different badges
   .alert-success .badge {

--- a/src/ui/public/notify/partials/toaster.html
+++ b/src/ui/public/notify/partials/toaster.html
@@ -7,9 +7,7 @@
 
         <i class="fa" ng-class="'fa-' + notif.icon" tooltip="{{notif.title}}"></i>
 
-        <kbn-truncated ng-if="notif.content" source="{{notif.content}}" length="250" class="toast-message" /></kbn-truncated>
-
-        <kbn-truncated ng-if="notif.markdown" source="{{notif.markdown | markdown}}" is-html="true" length="250" class="toast-message" /></kbn-truncated>
+        <kbn-truncated source="{{notif.content | markdown}}" is-html="true" length="250" class="toast-message" /></kbn-truncated>
 
         <div class="btn-group pull-right toast-controls">
           <button


### PR DESCRIPTION
- Remove the `content` vs `markdown` difference in all notifications
- Run all content through the markdown parser
- Tweak styles to handle injected `<p>` on content
- Add options parameter to notifications to override `lifetime` and `icon` (limited)
- Tweak `custom` notification type
  - First parameter is now the text
  - Default config borrows timeout from `info` type
  - Use `actions` instead of `customActions`
- Update the tests
