### PR TITLE
Add plugin test for sync/error cases

### DIFF
--- a/x-pack/plugins/reporting/server/plugin.test.ts
+++ b/x-pack/plugins/reporting/server/plugin.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+jest.mock('./browsers/install', () => ({
+  installBrowser: jest.fn().mockImplementation(() => ({
+    binaryPath$: {
+      pipe: jest.fn().mockImplementation(() => ({
+        toPromise: () => Promise.resolve(),
+      })),
+    },
+  })),
+}));
+
+import { coreMock } from 'src/core/server/mocks';
+import { ReportingPlugin } from './plugin';
+import { createMockConfig } from './test_helpers';
+
+const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
+
+describe('Reporting Plugin', () => {
+  let config: any;
+  let initContext: any;
+  let coreSetup: any;
+  let coreStart: any;
+  let pluginSetup: any;
+  let pluginStart: any;
+
+  beforeEach(async () => {
+    config = createMockConfig();
+    initContext = coreMock.createPluginInitializerContext(config);
+    coreSetup = await coreMock.createSetup(config);
+    coreStart = await coreMock.createStart();
+    pluginSetup = ({
+      licensing: {},
+      usageCollection: {
+        makeUsageCollector: jest.fn(),
+        registerCollector: jest.fn(),
+      },
+      security: {
+        authc: {
+          getCurrentUser: () => ({
+            id: '123',
+            roles: ['superuser'],
+            username: 'Tom Riddle',
+          }),
+        },
+      },
+    } as unknown) as any;
+    pluginStart = ({
+      data: {
+        fieldFormats: {},
+      },
+    } as unknown) as any;
+  });
+
+  it('has a sync setup process', () => {
+    const plugin = new ReportingPlugin(initContext);
+
+    expect(plugin.setup(coreSetup, pluginSetup)).not.toHaveProperty('then');
+  });
+
+  it('logs setup issues', async () => {
+    const plugin = new ReportingPlugin(initContext);
+    // @ts-ignore overloading error logger
+    plugin.logger.error = jest.fn();
+    coreSetup.elasticsearch = null;
+    plugin.setup(coreSetup, pluginSetup);
+
+    await sleep(5);
+
+    // @ts-ignore overloading error logger
+    expect(plugin.logger.error.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "Error in Reporting setup, reporting may not function properly
+      TypeError: Cannot read property 'legacy' of null
+          at jobsQueryFactory (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/lib/jobs_query.ts:50:48)
+          at registerJobInfoRoutes (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/routes/jobs.ts:30:21)
+          at registerRoutes (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/routes/index.ts:14:3)
+          at /Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/plugin.ts:54:7
+          at process._tickCallback (internal/process/next_tick.js:68:7)",
+        ],
+      ]
+    `);
+  });
+
+  it('has a sync startup process', async () => {
+    const plugin = new ReportingPlugin(initContext);
+    plugin.setup(coreSetup, pluginSetup);
+    await sleep(5);
+    expect(plugin.start(coreStart, pluginStart)).not.toHaveProperty('then');
+  });
+
+  it('logs start issues', async () => {
+    const plugin = new ReportingPlugin(initContext);
+    // @ts-ignore overloading error logger
+    plugin.logger.error = jest.fn();
+    plugin.setup(coreSetup, pluginSetup);
+    await sleep(5);
+    plugin.start(null as any, pluginStart);
+    await sleep(10);
+    // @ts-ignore overloading error logger
+    expect(plugin.logger.error.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "Error in Reporting startup, reporting may not function properly
+      TypeError: Cannot read property 'savedObjects' of null
+          at /Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/plugin.ts:86:28",
+        ],
+      ]
+    `);
+  });
+});

--- a/x-pack/plugins/reporting/server/plugin.test.ts
+++ b/x-pack/plugins/reporting/server/plugin.test.ts
@@ -71,19 +71,11 @@ describe('Reporting Plugin', () => {
     await sleep(5);
 
     // @ts-ignore overloading error logger
-    expect(plugin.logger.error.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "Error in Reporting setup, reporting may not function properly
-      TypeError: Cannot read property 'legacy' of null
-          at jobsQueryFactory (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/lib/jobs_query.ts:50:48)
-          at registerJobInfoRoutes (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/routes/jobs.ts:30:21)
-          at registerRoutes (/Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/routes/index.ts:14:3)
-          at /Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/plugin.ts:54:7
-          at process._tickCallback (internal/process/next_tick.js:68:7)",
-        ],
-      ]
-    `);
+    expect(plugin.logger.error.mock.calls[0][0]).toMatch(
+      /Error in Reporting setup, reporting may not function properly/
+    );
+    // @ts-ignore overloading error logger
+    expect(plugin.logger.error).toHaveBeenCalledTimes(2);
   });
 
   it('has a sync startup process', async () => {
@@ -102,14 +94,10 @@ describe('Reporting Plugin', () => {
     plugin.start(null as any, pluginStart);
     await sleep(10);
     // @ts-ignore overloading error logger
-    expect(plugin.logger.error.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "Error in Reporting startup, reporting may not function properly
-      TypeError: Cannot read property 'savedObjects' of null
-          at /Users/joelgriffith/Projects/kibana/x-pack/plugins/reporting/server/plugin.ts:86:28",
-        ],
-      ]
-    `);
+    expect(plugin.logger.error.mock.calls[0][0]).toMatch(
+      /Error in Reporting start, reporting may not function properly/
+    );
+    // @ts-ignore overloading error logger
+    expect(plugin.logger.error).toHaveBeenCalledTimes(2);
   });
 });

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -57,9 +57,8 @@ export class ReportingPlugin
       this.logger.debug('Setup complete');
       this.setup$.next(true);
     })().catch((e) => {
-      this.logger.error(
-        `Error in Reporting setup, reporting may not function properly\n` + e.stack
-      );
+      this.logger.error(`Error in Reporting setup, reporting may not function properly`);
+      this.logger.error(e);
     });
 
     return {};
@@ -95,9 +94,8 @@ export class ReportingPlugin
       this.logger.debug('Start complete');
       this.start$.next(true);
     })().catch((e) => {
-      this.logger.error(
-        `Error in Reporting startup, reporting may not function properly\n` + e.stack
-      );
+      this.logger.error(`Error in Reporting start, reporting may not function properly`);
+      this.logger.error(e);
     });
 
     return {};

--- a/x-pack/plugins/reporting/server/plugin.ts
+++ b/x-pack/plugins/reporting/server/plugin.ts
@@ -38,7 +38,8 @@ export class ReportingPlugin
     const basePath = http.basePath.get;
 
     // async background setup
-    buildConfig(initContext, core, this.logger).then((config) => {
+    (async () => {
+      const config = await buildConfig(initContext, core, this.logger);
       const reportingCore = new ReportingCore(config);
 
       reportingCore.pluginSetup({
@@ -55,6 +56,10 @@ export class ReportingPlugin
 
       this.logger.debug('Setup complete');
       this.setup$.next(true);
+    })().catch((e) => {
+      this.logger.error(
+        `Error in Reporting setup, reporting may not function properly\n` + e.stack
+      );
     });
 
     return {};
@@ -70,7 +75,8 @@ export class ReportingPlugin
     const { elasticsearch } = reportingCore.getPluginSetupDeps();
 
     // async background start
-    initializeBrowserDriverFactory(config, logger).then(async (browserDriverFactory) => {
+    (async () => {
+      const browserDriverFactory = await initializeBrowserDriverFactory(config, logger);
       reportingCore.setBrowserDriverFactory(browserDriverFactory);
 
       const esqueue = await createQueueFactory(reportingCore, logger);
@@ -88,6 +94,10 @@ export class ReportingPlugin
 
       this.logger.debug('Start complete');
       this.start$.next(true);
+    })().catch((e) => {
+      this.logger.error(
+        `Error in Reporting startup, reporting may not function properly\n` + e.stack
+      );
     });
 
     return {};

--- a/x-pack/plugins/reporting/server/routes/jobs.ts
+++ b/x-pack/plugins/reporting/server/routes/jobs.ts
@@ -22,7 +22,7 @@ interface ListQuery {
 }
 const MAIN_ENTRY = `${API_BASE_URL}/jobs`;
 
-export async function registerJobInfoRoutes(reporting: ReportingCore) {
+export function registerJobInfoRoutes(reporting: ReportingCore) {
   const config = reporting.getConfig();
   const setupDeps = reporting.getPluginSetupDeps();
   const userHandler = authorizedUserPreRoutingFactory(reporting);

--- a/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/create_mock_reportingplugin.ts
@@ -36,30 +36,35 @@ const createMockSetupDeps = (setupMock?: any): ReportingSetupDeps => {
     licensing: {
       license$: of({ isAvailable: true, isActive: true, type: 'basic' }),
     } as any,
-    usageCollection: {} as any,
+    usageCollection: {
+      makeUsageCollector: jest.fn(),
+      registerCollector: jest.fn(),
+    } as any,
   };
 };
+
+export const createMockConfig = (overrides?: any) => ({
+  index: '.reporting',
+  kibanaServer: {
+    hostname: 'localhost',
+    port: '80',
+  },
+  capture: {
+    browser: {
+      chromium: {
+        disableSandbox: true,
+      },
+    },
+  },
+  ...overrides,
+});
 
 export const createMockStartDeps = (startMock?: any): ReportingStartDeps => ({
   data: startMock.data,
 });
 
 const createMockReportingPlugin = async (config: ReportingConfig): Promise<ReportingPlugin> => {
-  const mockConfig = {
-    index: '.reporting',
-    kibanaServer: {
-      hostname: 'localhost',
-      port: '80',
-    },
-    capture: {
-      browser: {
-        chromium: {
-          disableSandbox: true,
-        },
-      },
-    },
-    ...config,
-  };
+  const mockConfig = createMockConfig(config);
   const plugin = new ReportingPlugin(coreMock.createPluginInitializerContext(mockConfig));
   const setupMock = coreMock.createSetup();
   const coreStartMock = coreMock.createStart();

--- a/x-pack/plugins/reporting/server/test_helpers/index.ts
+++ b/x-pack/plugins/reporting/server/test_helpers/index.ts
@@ -5,6 +5,6 @@
  */
 
 export { createMockServer } from './create_mock_server';
-export { createMockReportingCore } from './create_mock_reportingplugin';
+export { createMockReportingCore, createMockConfig } from './create_mock_reportingplugin';
 export { createMockBrowserDriverFactory } from './create_mock_browserdriverfactory';
 export { createMockLayoutInstance } from './create_mock_layoutinstance';


### PR DESCRIPTION
Adds in a plugin.ts test (just 4 quick specs). Also wraps our async setup/start tasks in an async block so we can `.catch` them more cleanly.