### PR TITLE
Reporting/register routes synchro

### DIFF
--- a/x-pack/plugins/reporting/server/routes/generation.test.ts
+++ b/x-pack/plugins/reporting/server/routes/generation.test.ts
@@ -18,6 +18,7 @@ import { of } from 'rxjs';
 type setupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 
 describe('POST /api/reporting/generate', () => {
+  const reportingSymbol = Symbol('reporting');
   let server: setupServerReturn['server'];
   let httpSetup: setupServerReturn['httpSetup'];
   let exportTypesRegistry: ExportTypesRegistry;
@@ -47,7 +48,8 @@ describe('POST /api/reporting/generate', () => {
   } as unknown) as jest.Mocked<LevelLogger>;
 
   beforeEach(async () => {
-    ({ server, httpSetup } = await setupServer());
+    ({ server, httpSetup } = await setupServer(reportingSymbol));
+    httpSetup.registerRouteHandlerContext(reportingSymbol, 'reporting', () => ({}));
     const mockDeps = ({
       elasticsearch: {
         legacy: {

--- a/x-pack/plugins/reporting/server/routes/jobs.test.ts
+++ b/x-pack/plugins/reporting/server/routes/jobs.test.ts
@@ -19,6 +19,7 @@ import { registerJobInfoRoutes } from './jobs';
 type setupServerReturn = UnwrapPromise<ReturnType<typeof setupServer>>;
 
 describe('GET /api/reporting/jobs/download', () => {
+  const reportingSymbol = Symbol('reporting');
   let server: setupServerReturn['server'];
   let httpSetup: setupServerReturn['httpSetup'];
   let exportTypesRegistry: ExportTypesRegistry;
@@ -39,7 +40,8 @@ describe('GET /api/reporting/jobs/download', () => {
   };
 
   beforeEach(async () => {
-    ({ server, httpSetup } = await setupServer());
+    ({ server, httpSetup } = await setupServer(reportingSymbol));
+    httpSetup.registerRouteHandlerContext(reportingSymbol, 'reporting', () => ({}));
     core = await createMockReportingCore(config, ({
       elasticsearch: {
         legacy: { client: { callAsInternalUser: jest.fn() } },


### PR DESCRIPTION
Fixes both generation/job test suites (needed to register the new context property).