### PR TITLE
display switch to space only when space is not active space

### DIFF
--- a/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
+  EuiIconTip,
   EuiPanel,
   EuiSpacer,
   EuiText,
@@ -555,30 +556,27 @@ export const EditRolePage: FunctionComponent<Props> = ({
 
   const getElasticsearchPrivileges = () => {
     return (
-      <div>
-        <EuiSpacer />
-        <ElasticsearchPrivileges
-          role={role}
-          editable={!isRoleReadOnly}
-          indicesAPIClient={indicesAPIClient}
-          onChange={onRoleChange}
-          runAsUsers={runAsUsers}
-          validator={validator}
-          indexPatterns={indexPatternsTitles}
-          remoteClusters={remoteClustersState.value}
-          builtinESPrivileges={builtInESPrivileges}
-          license={license}
-          docLinks={docLinks}
-          canUseRemoteIndices={
-            buildFlavor === 'traditional' && featureCheckState.value?.canUseRemoteIndices
-          }
-          canUseRemoteClusters={
-            buildFlavor === 'traditional' && featureCheckState.value?.canUseRemoteClusters
-          }
-          isDarkMode={isDarkMode}
-          buildFlavor={buildFlavor}
-        />
-      </div>
+      <ElasticsearchPrivileges
+        role={role}
+        editable={!isRoleReadOnly}
+        indicesAPIClient={indicesAPIClient}
+        onChange={onRoleChange}
+        runAsUsers={runAsUsers}
+        validator={validator}
+        indexPatterns={indexPatternsTitles}
+        remoteClusters={remoteClustersState.value}
+        builtinESPrivileges={builtInESPrivileges}
+        license={license}
+        docLinks={docLinks}
+        canUseRemoteIndices={
+          buildFlavor === 'traditional' && featureCheckState.value?.canUseRemoteIndices
+        }
+        canUseRemoteClusters={
+          buildFlavor === 'traditional' && featureCheckState.value?.canUseRemoteClusters
+        }
+        isDarkMode={isDarkMode}
+        buildFlavor={buildFlavor}
+      />
     );
   };
 
@@ -586,21 +584,18 @@ export const EditRolePage: FunctionComponent<Props> = ({
 
   const getKibanaPrivileges = () => {
     return (
-      <div>
-        <EuiSpacer />
-        <KibanaPrivilegesRegion
-          kibanaPrivileges={new KibanaPrivileges(kibanaPrivileges, features)}
-          spaces={spaces.list}
-          spacesEnabled={spaces.enabled}
-          uiCapabilities={uiCapabilities}
-          canCustomizeSubFeaturePrivileges={license.getFeatures().allowSubFeaturePrivileges}
-          editable={!isRoleReadOnly}
-          role={role}
-          onChange={onRoleChange}
-          validator={validator}
-          spacesApiUi={spacesApiUi}
-        />
-      </div>
+      <KibanaPrivilegesRegion
+        kibanaPrivileges={new KibanaPrivileges(kibanaPrivileges, features)}
+        spaces={spaces.list}
+        spacesEnabled={spaces.enabled}
+        uiCapabilities={uiCapabilities}
+        canCustomizeSubFeaturePrivileges={license.getFeatures().allowSubFeaturePrivileges}
+        editable={!isRoleReadOnly}
+        role={role}
+        onChange={onRoleChange}
+        validator={validator}
+        spacesApiUi={spacesApiUi}
+      />
     );
   };
 
@@ -797,44 +792,89 @@ export const EditRolePage: FunctionComponent<Props> = ({
 
   return (
     <div className="editRolePage">
-      <EuiForm {...formError}>
-        {getFormTitle()}
-        <EuiSpacer />
-        <EuiText size="s">
-          <FormattedMessage
-            id="xpack.security.management.editRole.setPrivilegesToKibanaSpacesDescription"
-            defaultMessage="Set privileges on your Elasticsearch data and control access to your Project spaces."
-          />
-        </EuiText>
-        {isRoleReserved && (
-          <Fragment>
-            <EuiSpacer size="s" />
-            <EuiText size="s" color="subdued">
-              <p id="reservedRoleDescription" tabIndex={0}>
-                <FormattedMessage
-                  id="xpack.security.management.editRole.modifyingReversedRolesDescription"
-                  defaultMessage="Reserved roles are built-in and cannot be removed or modified."
-                />
-              </p>
+      <EuiForm {...formError} fullWidth>
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            {getFormTitle()}
+            <EuiSpacer />
+            <EuiText size="s">
+              <FormattedMessage
+                id="xpack.security.management.editRole.setPrivilegesToKibanaSpacesDescription"
+                defaultMessage="Set privileges on your Elasticsearch data and control access to your Project spaces."
+              />
             </EuiText>
-          </Fragment>
-        )}
-        {isDeprecatedRole && (
-          <Fragment>
-            <EuiSpacer size="s" />
-            <EuiCallOut
-              title={getExtendedRoleDeprecationNotice(role)}
-              color="warning"
-              iconType="warning"
-            />
-          </Fragment>
-        )}
-        <EuiSpacer />
-        {getRoleNameAndDescription()}
-        {getElasticsearchPrivileges()}
-        {getKibanaPrivileges()}
-        <EuiSpacer />
-        {getFormButtons()}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {isRoleReserved && (
+              <Fragment>
+                <EuiText size="s" color="subdued">
+                  <p id="reservedRoleDescription" tabIndex={0}>
+                    <FormattedMessage
+                      id="xpack.security.management.editRole.modifyingReversedRolesDescription"
+                      defaultMessage="Reserved roles are built-in and cannot be removed or modified."
+                    />
+                  </p>
+                </EuiText>
+              </Fragment>
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {isDeprecatedRole && (
+              <Fragment>
+                <EuiSpacer size="s" />
+                <EuiCallOut
+                  title={getExtendedRoleDeprecationNotice(role)}
+                  color="warning"
+                  iconType="warning"
+                />
+              </Fragment>
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem>{getRoleNameAndDescription()}</EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow
+              label={
+                <FormattedMessage
+                  id="xpack.security.management.editRole.dataLayerLabel"
+                  defaultMessage="Data Layer"
+                />
+              }
+            >
+              {getElasticsearchPrivileges()}
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow
+              label={
+                <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <FormattedMessage
+                      id="xpack.security.management.editRole.appLayerLabel"
+                      defaultMessage="Application layer"
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiIconTip
+                      type="iInCircle"
+                      color="subdued"
+                      content={
+                        <FormattedMessage
+                          id="xpack.security.management.editRole.appLayerTooltipText"
+                          defaultMessage="Feature access is granted on a per space basis for all features. Feature visibility is set on the space. Both must be enabled for this role to use a feature"
+                        />
+                      }
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              }
+            >
+              {getKibanaPrivileges()}
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow fullWidth={false}>{getFormButtons()}</EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiForm>
     </div>
   );

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
@@ -105,10 +105,18 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
             <h2>
               <FormattedMessage
                 id="xpack.security.management.editRole.spacePrivilegeForm.modalTitle"
-                defaultMessage="Kibana privileges"
+                defaultMessage="Assign role to space"
               />
             </h2>
           </EuiTitle>
+          <EuiText size="s">
+            <p>
+              <FormattedMessage
+                id="xpack.security.management.editRole.spacePrivilegeForm.modalHeadline"
+                defaultMessage="This role will be granted access to the following spaces"
+              />
+            </p>
+          </EuiText>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
           <EuiErrorBoundary>{this.getForm()}</EuiErrorBoundary>

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_aware_privilege_section.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_aware_privilege_section.tsx
@@ -206,7 +206,7 @@ export class SpaceAwarePrivilegeSection extends Component<Props, State> {
         >
           <FormattedMessage
             id="xpack.security.management.editRole.spacePrivilegeSection.addSpacePrivilegeButton"
-            defaultMessage="Add Kibana privilege"
+            defaultMessage="Assign to space"
           />
         </EuiButton>
       );

--- a/x-pack/plugins/spaces/common/index.ts
+++ b/x-pack/plugins/spaces/common/index.ts
@@ -12,7 +12,11 @@ export {
   ENTER_SPACE_PATH,
   DEFAULT_SPACE_ID,
 } from './constants';
-export { addSpaceIdToPath, getSpaceIdFromPath } from './lib/spaces_url_parser';
+export {
+  addSpaceIdToPath,
+  getSpaceIdFromPath,
+  getSpaceNavigationURL,
+} from './lib/spaces_url_parser';
 export type {
   Space,
   GetAllSpacesOptions,

--- a/x-pack/plugins/spaces/common/lib/spaces_url_parser.ts
+++ b/x-pack/plugins/spaces/common/lib/spaces_url_parser.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { DEFAULT_SPACE_ID } from '../constants';
+import { DEFAULT_SPACE_ID, ENTER_SPACE_PATH } from '../constants';
 
 const spaceContextRegex = /^\/s\/([a-z0-9_\-]+)/;
 
@@ -73,6 +73,23 @@ export function addSpaceIdToPath(
     return `${normalizedBasePath}/s/${spaceId}${requestedPath}`;
   }
   return `${normalizedBasePath}${requestedPath}` || '/';
+}
+
+/**
+ * Builds URL that will navigate a user to the space for the spaceId provided
+ */
+export function getSpaceNavigationURL({
+  serverBasePath,
+  spaceId,
+}: {
+  serverBasePath: string;
+  spaceId: string;
+}) {
+  return addSpaceIdToPath(
+    serverBasePath,
+    spaceId,
+    `${ENTER_SPACE_PATH}?next=/app/management/kibana/spaces/view/${spaceId}`
+  );
 }
 
 function stripServerBasePath(requestBasePath: string, serverBasePath: string) {

--- a/x-pack/plugins/spaces/public/management/edit_space/enabled_features/__snapshots__/enabled_features.test.tsx.snap
+++ b/x-pack/plugins/spaces/public/management/edit_space/enabled_features/__snapshots__/enabled_features.test.tsx.snap
@@ -70,6 +70,15 @@ exports[`EnabledFeatures renders as expected 1`] = `
             },
           ]
         }
+        headerText={
+          <EuiText
+            size="xs"
+          >
+            <b>
+              Feature visibility
+            </b>
+          </EuiText>
+        }
         onChange={[MockFunction]}
         space={
           Object {

--- a/x-pack/plugins/spaces/public/management/edit_space/enabled_features/feature_table.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/enabled_features/feature_table.tsx
@@ -256,9 +256,7 @@ export class FeatureTable extends Component<Props, {}> {
     }
 
     updatedSpace.disabledFeatures = disabledFeatures;
-    if (this.props.onChange) {
-      this.props.onChange(updatedSpace);
-    }
+    this.props.onChange?.(updatedSpace);
   };
 
   private getAllFeatureIds = () =>
@@ -287,9 +285,7 @@ export class FeatureTable extends Component<Props, {}> {
       );
     }
 
-    if (this.props.onChange) {
-      this.props.onChange(updatedSpace);
-    }
+    this.props.onChange?.(updatedSpace);
   };
 
   private getCategoryHelpText = (category: AppCategory) => {

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -124,11 +124,15 @@ export class SpacesGridPage extends Component<Props, State> {
         ) : undefined}
         <EuiInMemoryTable
           itemId={'id'}
+          data-test-subj={'spacesListTable'}
           items={this.state.spaces}
           tableCaption={i18n.translate('xpack.spaces.management.spacesGridPage.tableCaption', {
             defaultMessage: 'Kibana spaces',
           })}
           rowHeader="name"
+          rowProps={(item) => ({
+            'data-test-subj': `spacesListTableRow-${item.id}`,
+          })}
           columns={this.getColumnConfig()}
           pagination={true}
           sorting={true}
@@ -255,7 +259,10 @@ export class SpacesGridPage extends Component<Props, State> {
         }),
         sortable: true,
         render: (value: string, record: Space) => (
-          <EuiLink {...reactRouterNavigate(this.props.history, this.getViewSpacePath(record))}>
+          <EuiLink
+            {...reactRouterNavigate(this.props.history, this.getViewSpacePath(record))}
+            data-test-subj={`${record.id}-hyperlink`}
+          >
             {value}
           </EuiLink>
         ),

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -71,6 +71,7 @@ export const spacesManagementApp = Object.freeze({
               getFeatures={features.getFeatures}
               notifications={notifications}
               spacesManager={spacesManager}
+              serverBasePath={http.basePath.serverBasePath}
               history={history}
               getUrlForApp={application.getUrlForApp}
               maxSpaces={config.maxSpaces}

--- a/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
@@ -30,7 +30,7 @@ import type { Role } from '@kbn/security-plugin-types-common';
 import { TAB_ID_CONTENT, TAB_ID_FEATURES, TAB_ID_ROLES } from './constants';
 import { useTabs } from './hooks/use_tabs';
 import { ViewSpaceContextProvider } from './hooks/view_space_context_provider';
-import { addSpaceIdToPath, ENTER_SPACE_PATH, type Space } from '../../../common';
+import { getSpaceNavigationURL, type Space } from '../../../common';
 import { getSpaceAvatarComponent } from '../../space_avatar';
 import type { SpacesManager } from '../../spaces_manager';
 
@@ -187,11 +187,6 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
     }
 
     const { serverBasePath } = props;
-    const urlToSelectedSpace = addSpaceIdToPath(
-      serverBasePath,
-      space.id,
-      `${ENTER_SPACE_PATH}?next=/app/management/kibana/spaces/view/${space.id}`
-    );
 
     if (userActiveSpace?.id === space.id) {
       return null;
@@ -199,7 +194,11 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
 
     // use href to force full page reload (needed in order to change spaces)
     return (
-      <EuiButton iconType="merge" href={urlToSelectedSpace} data-test-subj="spaceSwitcherButton">
+      <EuiButton
+        iconType="merge"
+        href={getSpaceNavigationURL({ serverBasePath, spaceId: space.id })}
+        data-test-subj="spaceSwitcherButton"
+      >
         <FormattedMessage
           id="xpack.spaces.management.spaceDetails.space.switchToSpaceButton.label"
           defaultMessage="Switch to this space"

--- a/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
@@ -199,9 +199,9 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
 
     // use href to force full page reload (needed in order to change spaces)
     return (
-      <EuiButton iconType="merge" href={urlToSelectedSpace}>
+      <EuiButton iconType="merge" href={urlToSelectedSpace} data-test-subj="spaceSwitcherButton">
         <FormattedMessage
-          id="viewSpace.switchToSpaceButton.label"
+          id="xpack.spaces.management.spaceDetails.space.switchToSpaceButton.label"
           defaultMessage="Switch to this space"
         />
       </EuiButton>
@@ -216,19 +216,19 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
       getUrlForApp={getUrlForApp}
     >
       <EuiText>
-        <EuiFlexGroup>
+        <EuiFlexGroup data-test-subj="spaceDetailsHeader">
           <EuiFlexItem grow={false}>
             <HeaderAvatar />
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="l">
-              <h1>{space.name}</h1>
+              <h1 data-test-subj="spaceTitle">{space.name}</h1>
             </EuiTitle>
             <EuiText size="s">
               <p>
                 {space.description ?? (
                   <FormattedMessage
-                    id="viewSpace.description"
+                    id="xpack.spaces.management.spaceDetails.space.description"
                     defaultMessage="Organize your saved objects and show related features for creating new content."
                   />
                 )}

--- a/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
@@ -16,12 +16,14 @@ import {
   EuiTab,
   EuiTabs,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import React, { lazy, Suspense, useEffect, useState } from 'react';
 import type { FC } from 'react';
 
 import type { ApplicationStart, Capabilities, ScopedHistory } from '@kbn/core/public';
 import type { FeaturesPluginStart, KibanaFeature } from '@kbn/features-plugin/public';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { reactRouterNavigate } from '@kbn/kibana-react-plugin/public';
 import type { Role } from '@kbn/security-plugin-types-common';
 
@@ -76,6 +78,7 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
   const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
   const selectedTabId = getSelectedTabId(_selectedTabId);
   const [space, setSpace] = useState<Space | null>(null);
+  const [userActiveSpace, setUserActiveSpace] = useState<Space | null>(null);
   const [features, setFeatures] = useState<KibanaFeature[] | null>(null);
   const [roles, setRoles] = useState<Role[]>([]);
   const [isLoadingSpace, setIsLoadingSpace] = useState(true);
@@ -94,26 +97,20 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
     if (!spaceId) {
       return;
     }
-    const getSpace = async () => {
-      const result = await spacesManager.getSpace(spaceId);
-      if (!result) {
-        throw new Error(`Could not get resulting space by id ${spaceId}`);
-      }
-      setSpace(result);
+
+    const getSpaceInfo = async () => {
+      const [activeSpace, currentSpace] = await Promise.all([
+        spacesManager.getActiveSpace(),
+        spacesManager.getSpace(spaceId),
+      ]);
+
+      setSpace(currentSpace);
+      setUserActiveSpace(activeSpace);
       setIsLoadingSpace(false);
     };
 
-    getSpace().catch(handleApiError);
+    getSpaceInfo().catch(handleApiError);
   }, [spaceId, spacesManager]);
-
-  useEffect(() => {
-    const _getFeatures = async () => {
-      const result = await getFeatures();
-      setFeatures(result);
-      setIsLoadingFeatures(false);
-    };
-    _getFeatures().catch(handleApiError);
-  }, [getFeatures]);
 
   useEffect(() => {
     if (spaceId) {
@@ -127,12 +124,23 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
     }
   }, [spaceId, spacesManager]);
 
+  useEffect(() => {
+    const _getFeatures = async () => {
+      const result = await getFeatures();
+      setFeatures(result);
+      setIsLoadingFeatures(false);
+    };
+    _getFeatures().catch(handleApiError);
+  }, [getFeatures]);
+
+  useEffect(() => {
+    if (space) {
+      onLoadSpace?.(space);
+    }
+  }, [onLoadSpace, space]);
+
   if (!space) {
     return null;
-  }
-
-  if (onLoadSpace) {
-    onLoadSpace(space);
   }
 
   if (isLoadingSpace || isLoadingFeatures || isLoadingRoles) {
@@ -146,27 +154,9 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
   }
 
   const HeaderAvatar = () => {
-    return space.imageUrl != null ? (
+    return (
       <Suspense fallback={<EuiLoadingSpinner />}>
-        <LazySpaceAvatar
-          space={{
-            ...space,
-            initials: space.initials ?? 'X',
-            name: undefined,
-          }}
-          size="xl"
-        />
-      </Suspense>
-    ) : (
-      <Suspense fallback={<EuiLoadingSpinner />}>
-        <LazySpaceAvatar
-          space={{
-            ...space,
-            name: space.name ?? 'Y',
-            imageUrl: undefined,
-          }}
-          size="xl"
-        />
+        <LazySpaceAvatar space={space} size="xl" />
       </Suspense>
     );
   };
@@ -184,7 +174,9 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
           navigateToUrl(href);
         }}
       >
-        <EuiButtonEmpty iconType="gear">Settings</EuiButtonEmpty>
+        <EuiButtonEmpty iconType="gear">
+          <FormattedMessage id="viewSpace.spaceSettingsButton.label" defaultMessage="Settings" />
+        </EuiButtonEmpty>
       </a>
     ) : null;
   };
@@ -201,10 +193,17 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
       `${ENTER_SPACE_PATH}?next=/app/management/kibana/spaces/view/${space.id}`
     );
 
+    if (userActiveSpace?.id === space.id) {
+      return null;
+    }
+
     // use href to force full page reload (needed in order to change spaces)
     return (
       <EuiButton iconType="merge" href={urlToSelectedSpace}>
-        Switch to this space
+        <FormattedMessage
+          id="viewSpace.switchToSpaceButton.label"
+          defaultMessage="Switch to this space"
+        />
       </EuiButton>
     );
   };
@@ -222,13 +221,19 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
             <HeaderAvatar />
           </EuiFlexItem>
           <EuiFlexItem>
-            <h1>{space.name}</h1>
-            <p>
-              <small>
-                {space.description ??
-                  'Organize your saved objects and show related features for creating new content.'}
-              </small>
-            </p>
+            <EuiTitle size="l">
+              <h1>{space.name}</h1>
+            </EuiTitle>
+            <EuiText size="s">
+              <p>
+                {space.description ?? (
+                  <FormattedMessage
+                    id="viewSpace.description"
+                    defaultMessage="Organize your saved objects and show related features for creating new content."
+                  />
+                )}
+              </p>
+            </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup alignItems="center">
@@ -244,22 +249,26 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
 
         <EuiSpacer />
 
-        <EuiTabs>
-          {tabs.map((tab, index) => (
-            <EuiTab
-              key={index}
-              isSelected={tab.id === selectedTabId}
-              append={tab.append}
-              {...reactRouterNavigate(history, `/view/${encodeURIComponent(space.id)}/${tab.id}`)}
-            >
-              {tab.name}
-            </EuiTab>
-          ))}
-        </EuiTabs>
-
-        <EuiSpacer />
-
-        {selectedTabContent ?? null}
+        <EuiFlexGroup direction="column">
+          <EuiFlexItem>
+            <EuiTabs>
+              {tabs.map((tab, index) => (
+                <EuiTab
+                  key={index}
+                  isSelected={tab.id === selectedTabId}
+                  append={tab.append}
+                  {...reactRouterNavigate(
+                    history,
+                    `/view/${encodeURIComponent(space.id)}/${tab.id}`
+                  )}
+                >
+                  {tab.name}
+                </EuiTab>
+              ))}
+            </EuiTabs>
+          </EuiFlexItem>
+          <EuiFlexItem>{selectedTabContent ?? null}</EuiFlexItem>
+        </EuiFlexGroup>
       </EuiText>
     </ViewSpaceContextProvider>
   );

--- a/x-pack/plugins/spaces/public/management/view_space/view_space_roles.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space_roles.tsx
@@ -16,11 +16,14 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { Role } from '@kbn/security-plugin-types-common';
 
 import type { Space } from '../../../common';
@@ -52,11 +55,15 @@ export const ViewSpaceAssignedRoles: FC<Props> = ({ space, roles }) => {
   const columns: Array<EuiBasicTableColumn<Role>> = [
     {
       field: 'name',
-      name: 'Role',
+      name: i18n.translate('xpack.spaces.management.spaceDetails.roles.column.name.title', {
+        defaultMessage: 'Role',
+      }),
     },
     {
       field: 'privileges',
-      name: 'Privileges',
+      name: i18n.translate('xpack.spaces.management.spaceDetails.roles.column.privileges.title', {
+        defaultMessage: 'Privileges',
+      }),
       render: (_value, record) => {
         return record.kibana.map((kibanaPrivilege) => {
           return kibanaPrivilege.base.join(', ');
@@ -67,7 +74,12 @@ export const ViewSpaceAssignedRoles: FC<Props> = ({ space, roles }) => {
       name: 'Actions',
       actions: [
         {
-          name: 'Remove from space',
+          name: i18n.translate(
+            'xpack.spaces.management.spaceDetails.roles.column.actions.remove.title',
+            {
+              defaultMessage: 'Remove from space',
+            }
+          ),
           description: 'Click this action to remove the role privileges from this space.',
           onClick: () => {
             window.alert('Not yet implemented.');
@@ -103,29 +115,43 @@ export const ViewSpaceAssignedRoles: FC<Props> = ({ space, roles }) => {
           }}
         />
       )}
-      <EuiFlexGroup>
+      <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          <p>Roles that can access this space. Privileges are managed at the role level.</p>
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiText>
+                <p>
+                  {i18n.translate('xpack.spaces.management.spaceDetails.roles.heading', {
+                    defaultMessage:
+                      'Roles that can access this space. Privileges are managed at the role level.',
+                  })}
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} color="primary">
+              <EuiButton
+                onClick={() => {
+                  setShowRolesPrivilegeEditor(true);
+                }}
+              >
+                {i18n.translate('xpack.spaces.management.spaceDetails.roles.assign', {
+                  defaultMessage: 'Assign role',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={false} color="primary">
-          <EuiButton
-            onClick={() => {
-              setShowRolesPrivilegeEditor(true);
-            }}
-          >
-            Assign role
-          </EuiButton>
+        <EuiFlexItem>
+          <EuiBasicTable
+            tableCaption="Demo of EuiBasicTable"
+            rowHeader="firstName"
+            columns={columns}
+            items={rolesInUse}
+            rowProps={getRowProps}
+            cellProps={getCellProps}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
-
-      <EuiBasicTable
-        tableCaption="Demo of EuiBasicTable"
-        rowHeader="firstName"
-        columns={columns}
-        items={rolesInUse}
-        rowProps={getRowProps}
-        cellProps={getCellProps}
-      />
     </>
   );
 };
@@ -147,7 +173,9 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
   const getSaveButton = () => {
     return (
       <EuiButton onClick={onSaveClick} fill data-test-subj={'createRolesPrivilegeButton'}>
-        Assign roles
+        {i18n.translate('xpack.spaces.management.spaceDetails.roles.assignRoleButton', {
+          defaultMessage: 'Assign roles',
+        })}
       </EuiButton>
     );
   };
@@ -160,10 +188,14 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <p>
-          Roles will be granted access to the current space according to their default privileges.
-          Use the &lsquo;Customize&rsquo; option to override default privileges.
-        </p>
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.spaces.management.spaceDetails.privilegeForm.heading"
+              defaultMessage="Roles will be granted access to the current space according to their default privileges. Use the &lsquo;Customize&rsquo; option to override default privileges."
+            />
+          </p>
+        </EuiText>
         {getForm()}
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
@@ -175,7 +207,9 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
               flush="left"
               data-test-subj={'cancelRolesPrivilegeButton'}
             >
-              Cancel
+              {i18n.translate('xpack.spaces.management.spaceDetails.roles.cancelRoleButton', {
+                defaultMessage: 'Cancel',
+              })}
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{getSaveButton()}</EuiFlexItem>

--- a/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
@@ -9,6 +9,7 @@ import { EuiNotificationBadge } from '@elastic/eui';
 import React from 'react';
 
 import type { KibanaFeature } from '@kbn/features-plugin/common';
+import { i18n } from '@kbn/i18n';
 import type { Role } from '@kbn/security-plugin-types-common';
 
 import { TAB_ID_CONTENT, TAB_ID_FEATURES, TAB_ID_ROLES } from './constants';
@@ -33,12 +34,16 @@ export const getTabs = (space: Space, features: KibanaFeature[], roles: Role[]):
   return [
     {
       id: TAB_ID_CONTENT,
-      name: 'Content',
+      name: i18n.translate('xpack.spaces.management.spaceDetails.contentTabs.feature.heading', {
+        defaultMessage: 'Content',
+      }),
       content: <ViewSpaceContent space={space} />,
     },
     {
       id: TAB_ID_FEATURES,
-      name: 'Features',
+      name: i18n.translate('xpack.spaces.management.spaceDetails.contentTabs.feature.heading', {
+        defaultMessage: 'Feature visibility',
+      }),
       append: (
         <EuiNotificationBadge className="eui-alignCenter" size="m">
           {enabledFeatureCount} / {totalFeatureCount}
@@ -48,7 +53,9 @@ export const getTabs = (space: Space, features: KibanaFeature[], roles: Role[]):
     },
     {
       id: TAB_ID_ROLES,
-      name: 'Assigned roles',
+      name: i18n.translate('xpack.spaces.management.spaceDetails.contentTabs.roles.heading', {
+        defaultMessage: 'Assigned roles',
+      }),
       append: (
         <EuiNotificationBadge className="eui-alignCenter" size="m">
           {roles.length}

--- a/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
@@ -61,7 +61,7 @@ export const getTabs = (space: Space, features: KibanaFeature[], roles: Role[]):
           {roles.length}
         </EuiNotificationBadge>
       ),
-      content: <ViewSpaceAssignedRoles space={space} roles={roles} />,
+      content: <ViewSpaceAssignedRoles space={space} roles={roles} features={features} />,
     },
   ];
 };

--- a/x-pack/test/functional/apps/spaces/details_view/spaces_details_view.ts
+++ b/x-pack/test/functional/apps/spaces/details_view/spaces_details_view.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import crypto from 'crypto';
+import expect from '@kbn/expect';
+import { type FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function spaceDetailsViewFunctionalTests({
+  getService,
+  getPageObjects,
+}: FtrProviderContext) {
+  const PageObjects = getPageObjects(['common', 'settings', 'spaceSelector']);
+
+  const find = getService('find');
+  const retry = getService('retry');
+  const spacesServices = getService('spaces');
+  const testSubjects = getService('testSubjects');
+
+  describe('Spaces', function () {
+    const testSpacesIds = [
+      'odyssey',
+      // this number is chosen intentionally to not exceed the default 10 items displayed by spaces table
+      ...Array.from(new Array(5)).map((_) => `space-${crypto.randomUUID()}`),
+    ];
+
+    before(async () => {
+      for (const testSpaceId of testSpacesIds) {
+        await spacesServices.create({ id: testSpaceId, name: `${testSpaceId}-name` });
+      }
+    });
+
+    after(async () => {
+      for (const testSpaceId of testSpacesIds) {
+        await spacesServices.delete(testSpaceId);
+      }
+    });
+
+    describe('Space listing', () => {
+      before(async () => {
+        await PageObjects.settings.navigateTo();
+        await testSubjects.existOrFail('spaces');
+      });
+
+      beforeEach(async () => {
+        await PageObjects.common.navigateToUrl('management', 'kibana/spaces', {
+          ensureCurrentUrl: false,
+          shouldLoginIfPrompted: false,
+          shouldUseHashForSubUrl: false,
+        });
+
+        await testSubjects.existOrFail('spaces-grid-page');
+      });
+
+      it('should list all the spaces populated', async () => {
+        const renderedSpaceRow = await find.allByCssSelector(
+          '[data-test-subj*=spacesListTableRow-]'
+        );
+
+        expect(renderedSpaceRow.length).to.equal(testSpacesIds.length + 1);
+      });
+
+      it('does not display the space switcher button when viewing the details page for the current selected space', async () => {
+        const currentSpaceTitle = (
+          await PageObjects.spaceSelector.currentSelectedSpaceTitle()
+        )?.toLowerCase();
+
+        expect(currentSpaceTitle).to.equal('default');
+
+        await testSubjects.click('default-hyperlink');
+        await testSubjects.existOrFail('spaceDetailsHeader');
+        expect(
+          (await testSubjects.getVisibleText('spaceDetailsHeader'))
+            .toLowerCase()
+            .includes('default')
+        ).to.be(true);
+        await testSubjects.missingOrFail('spaceSwitcherButton');
+      });
+
+      it("displays the space switcher button when viewing the details page of the space that's not the current selected one", async () => {
+        const testSpaceId = testSpacesIds[Math.floor(Math.random() * testSpacesIds.length)];
+
+        const currentSpaceTitle = (
+          await PageObjects.spaceSelector.currentSelectedSpaceTitle()
+        )?.toLowerCase();
+
+        expect(currentSpaceTitle).to.equal('default');
+
+        await testSubjects.click(`${testSpaceId}-hyperlink`);
+        await testSubjects.existOrFail('spaceDetailsHeader');
+        expect(
+          (await testSubjects.getVisibleText('spaceDetailsHeader'))
+            .toLowerCase()
+            .includes(`${testSpaceId}-name`)
+        ).to.be(true);
+        await testSubjects.existOrFail('spaceSwitcherButton');
+      });
+
+      it('switches to a new space using the space switcher button', async () => {
+        const currentSpaceTitle = (
+          await PageObjects.spaceSelector.currentSelectedSpaceTitle()
+        )?.toLowerCase();
+
+        expect(currentSpaceTitle).to.equal('default');
+
+        const testSpaceId = testSpacesIds[Math.floor(Math.random() * testSpacesIds.length)];
+
+        await testSubjects.click(`${testSpaceId}-hyperlink`);
+        await testSubjects.click('spaceSwitcherButton');
+
+        await retry.try(async () => {
+          const detailsTitle = (
+            await testSubjects.getVisibleText('spaceDetailsHeader')
+          ).toLowerCase();
+
+          const currentSwitchSpaceTitle = (
+            await PageObjects.spaceSelector.currentSelectedSpaceTitle()
+          )?.toLocaleLowerCase();
+
+          return (
+            currentSwitchSpaceTitle &&
+            currentSwitchSpaceTitle === `${testSpaceId}-name` &&
+            detailsTitle.includes(currentSwitchSpaceTitle)
+          );
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/functional/apps/spaces/index.ts
+++ b/x-pack/test/functional/apps/spaces/index.ts
@@ -13,5 +13,6 @@ export default function spacesApp({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./feature_controls/spaces_security'));
     loadTestFile(require.resolve('./spaces_selection'));
     loadTestFile(require.resolve('./enter_space'));
+    loadTestFile(require.resolve('./details_view/spaces_details_view'));
   });
 }

--- a/x-pack/test/functional/page_objects/space_selector_page.ts
+++ b/x-pack/test/functional/page_objects/space_selector_page.ts
@@ -253,4 +253,9 @@ export class SpaceSelectorPageObject extends FtrService {
     );
     expect(await msgElem.getVisibleText()).to.be('no spaces found');
   }
+
+  async currentSelectedSpaceTitle() {
+    const spacesNavSelector = await this.find.byCssSelector('[data-test-subj="spacesNavSelector"]');
+    return spacesNavSelector.getAttribute('title');
+  }
 }


### PR DESCRIPTION
## Summary

- Switches static text for translations strings
- Only display switch to space button in space details page when user is not in the current space, also add tests for this
- Apply UI tweaks for role creation page
- Start on creating the assign to role flyout expereince

<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->