### PR TITLE
Assign Roles to Space

### DIFF
--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -6,9 +6,12 @@
  */
 
 import {
+  EuiBadge,
   type EuiBasicTableColumn,
   EuiButton,
   EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiInMemoryTable,
   EuiLink,
   EuiLoadingSpinner,
@@ -278,12 +281,25 @@ export class SpacesGridPage extends Component<Props, State> {
         }),
         sortable: true,
         render: (value: string, rowRecord) => (
-          <EuiLink
-            {...reactRouterNavigate(this.props.history, this.getViewSpacePath(rowRecord))}
-            data-test-subj={`${rowRecord.id}-hyperlink`}
-          >
-            {value}
-          </EuiLink>
+          <EuiFlexGroup responsive={false} alignItems="center" gutterSize="m">
+            <EuiFlexItem grow={false}>
+              <EuiLink
+                {...reactRouterNavigate(this.props.history, this.getViewSpacePath(rowRecord))}
+                data-test-subj={`${rowRecord.id}-hyperlink`}
+              >
+                {value}
+              </EuiLink>
+            </EuiFlexItem>
+            {this.state.activeSpace?.name === rowRecord.name && (
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="primary">
+                  {i18n.translate('xpack.spaces.management.spacesGridPage.currentSpaceMarkerText', {
+                    defaultMessage: 'current',
+                  })}
+                </EuiBadge>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
         ),
       },
       {

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -33,7 +33,13 @@ interface CreateParams {
 
 export const spacesManagementApp = Object.freeze({
   id: 'spaces',
-  create({ getStartServices, spacesManager, config, solutionNavExperiment }: CreateParams) {
+  create({
+    getStartServices,
+    spacesManager,
+    config,
+    solutionNavExperiment,
+    getRolesAPIClient,
+  }: CreateParams) {
     const title = i18n.translate('xpack.spaces.displayName', {
       defaultMessage: 'Spaces',
     });
@@ -160,6 +166,7 @@ export const spacesManagementApp = Object.freeze({
               onLoadSpace={onLoadSpace}
               spaceId={spaceId}
               selectedTabId={selectedTabId}
+              getRolesAPIClient={getRolesAPIClient}
             />
           );
         };

--- a/x-pack/plugins/spaces/public/management/view_space/hooks/use_tabs.ts
+++ b/x-pack/plugins/spaces/public/management/view_space/hooks/use_tabs.ts
@@ -8,25 +8,30 @@
 import { useMemo } from 'react';
 
 import type { KibanaFeature } from '@kbn/features-plugin/public';
-import type { Role } from '@kbn/security-plugin-types-common';
 
 import type { Space } from '../../../../common';
-import type { ViewSpaceTab } from '../view_space_tabs';
-import { getTabs } from '../view_space_tabs';
+import { getTabs, type GetTabsProps, type ViewSpaceTab } from '../view_space_tabs';
 
-export const useTabs = (
-  space: Space | null,
-  features: KibanaFeature[] | null,
-  roles: Role[],
-  currentSelectedTabId: string
-): [ViewSpaceTab[], JSX.Element | undefined] => {
+type UseTabsProps = Omit<GetTabsProps, 'space' | 'features'> & {
+  space: Space | null;
+  features: KibanaFeature[] | null;
+  currentSelectedTabId: string;
+};
+
+export const useTabs = ({
+  space,
+  features,
+  currentSelectedTabId,
+  ...getTabsArgs
+}: UseTabsProps): [ViewSpaceTab[], JSX.Element | undefined] => {
   const [tabs, selectedTabContent] = useMemo(() => {
-    if (space == null || features == null) {
+    if (space === null || features === null) {
       return [[]];
     }
-    const _tabs = space != null ? getTabs(space, features, roles) : [];
+
+    const _tabs = space != null ? getTabs({ space, features, ...getTabsArgs }) : [];
     return [_tabs, _tabs.find((obj) => obj.id === currentSelectedTabId)?.content];
-  }, [space, currentSelectedTabId, features, roles]);
+  }, [space, features, getTabsArgs, currentSelectedTabId]);
 
   return [tabs, selectedTabContent];
 };

--- a/x-pack/plugins/spaces/public/management/view_space/hooks/view_space_context_provider.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/hooks/view_space_context_provider.tsx
@@ -9,14 +9,16 @@ import type { FC, PropsWithChildren } from 'react';
 import React, { createContext, useContext } from 'react';
 
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { RolesAPIClient } from '@kbn/security-plugin-types-public';
 
 import type { SpacesManager } from '../../../spaces_manager';
 
-interface ViewSpaceServices {
+export interface ViewSpaceServices {
   serverBasePath: string;
   getUrlForApp: ApplicationStart['getUrlForApp'];
   navigateToUrl: ApplicationStart['navigateToUrl'];
   spacesManager: SpacesManager;
+  getRolesAPIClient: () => Promise<RolesAPIClient>;
 }
 
 const ViewSpaceContext = createContext<ViewSpaceServices | null>(null);

--- a/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
@@ -42,9 +42,12 @@ const LazySpaceAvatar = lazy(() =>
   getSpaceAvatarComponent().then((component) => ({ default: component }))
 );
 
-const getSelectedTabId = (selectedTabId?: string) => {
+const getSelectedTabId = (canUserViewRoles: boolean, selectedTabId?: string) => {
   // Validation of the selectedTabId routing parameter, default to the Content tab
-  return selectedTabId && [TAB_ID_FEATURES, TAB_ID_ROLES].includes(selectedTabId)
+  return selectedTabId &&
+    [TAB_ID_FEATURES, canUserViewRoles ? TAB_ID_ROLES : null]
+      .filter(Boolean)
+      .includes(selectedTabId)
     ? selectedTabId
     : TAB_ID_CONTENT;
 };
@@ -81,7 +84,6 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
     getRolesAPIClient,
   } = props;
 
-  const selectedTabId = getSelectedTabId(_selectedTabId);
   const [space, setSpace] = useState<Space | null>(null);
   const [userActiveSpace, setUserActiveSpace] = useState<Space | null>(null);
   const [features, setFeatures] = useState<KibanaFeature[] | null>(null);
@@ -89,8 +91,15 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
   const [isLoadingSpace, setIsLoadingSpace] = useState(true);
   const [isLoadingFeatures, setIsLoadingFeatures] = useState(true);
   const [isLoadingRoles, setIsLoadingRoles] = useState(true);
-  const [tabs, selectedTabContent] = useTabs(space, features, roles, selectedTabId);
   const [isSolutionNavEnabled, setIsSolutionNavEnabled] = useState(false);
+  const selectedTabId = getSelectedTabId(Boolean(capabilities?.roles?.view), _selectedTabId);
+  const [tabs, selectedTabContent] = useTabs({
+    space,
+    features,
+    roles,
+    capabilities,
+    currentSelectedTabId: selectedTabId,
+  });
 
   useEffect(() => {
     if (!spaceId) {

--- a/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space.tsx
@@ -201,32 +201,6 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
     ) : null;
   };
 
-  const SwitchButton = () => {
-    if (userActiveSpace?.id === space.id) {
-      return null;
-    }
-
-    const { serverBasePath } = props;
-
-    // use href to force full page reload (needed in order to change spaces)
-    return (
-      <EuiButton
-        iconType="merge"
-        href={addSpaceIdToPath(
-          serverBasePath,
-          space.id,
-          `${ENTER_SPACE_PATH}?next=/app/management/kibana/spaces/view/${space.id}`
-        )}
-        data-test-subj="spaceSwitcherButton"
-      >
-        <FormattedMessage
-          id="xpack.spaces.management.spaceDetails.space.switchToSpaceButton.label"
-          defaultMessage="Switch to this space"
-        />
-      </EuiButton>
-    );
-  };
-
   return (
     <ViewSpaceContextProvider
       getRolesAPIClient={getRolesAPIClient}
@@ -236,7 +210,7 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
       getUrlForApp={getUrlForApp}
     >
       <EuiText>
-        <EuiFlexGroup data-test-subj="spaceDetailsHeader">
+        <EuiFlexGroup data-test-subj="spaceDetailsHeader" alignItems="flexStart">
           <EuiFlexItem grow={false}>
             <HeaderAvatar />
           </EuiFlexItem>
@@ -280,13 +254,28 @@ export const ViewSpacePage: FC<PageProps> = (props) => {
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="center">
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
               <EuiFlexItem>
                 <SettingsButton />
               </EuiFlexItem>
-              <EuiFlexItem>
-                <SwitchButton />
-              </EuiFlexItem>
+              {userActiveSpace?.id !== space.id ? (
+                <EuiFlexItem>
+                  <EuiButton
+                    iconType="merge"
+                    href={addSpaceIdToPath(
+                      props.serverBasePath,
+                      space.id,
+                      `${ENTER_SPACE_PATH}?next=/app/management/kibana/spaces/view/${space.id}`
+                    )}
+                    data-test-subj="spaceSwitcherButton"
+                  >
+                    <FormattedMessage
+                      id="xpack.spaces.management.spaceDetails.space.switchToSpaceButton.label"
+                      defaultMessage="Switch to this space"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+              ) : null}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
@@ -85,7 +85,7 @@ export const getTabs = ({
       content: (
         <ViewSpaceAssignedRoles
           space={space}
-          roles={rest.roles}
+          spaceRoles={rest.roles}
           features={features}
           isReadOnly={!canUserModifyRoles}
         />

--- a/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
+++ b/x-pack/plugins/spaces/public/management/view_space/view_space_tabs.tsx
@@ -85,7 +85,7 @@ export const getTabs = ({
       content: (
         <ViewSpaceAssignedRoles
           space={space}
-          spaceRoles={rest.roles}
+          roles={rest.roles}
           features={features}
           isReadOnly={!canUserModifyRoles}
         />


### PR DESCRIPTION
## Summary

This PR builds on #11, focuses primarily on the business logic and UI interaction involved with assigning several roles to a space. 

A user that doesn't have capabilities to view roles will not be presented the roles tab, and in the same vein a user that doesn't have capability to save a modification to roles definition will not be presented options to modify roles assigned to a space. See https://github.com/elastic/kibana/issues/181315 for more clarification.

<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->