### PR TITLE
use same chromium path install method is invoked with for background install

### DIFF
--- a/x-pack/plugins/reporting/server/browsers/install.ts
+++ b/x-pack/plugins/reporting/server/browsers/install.ts
@@ -35,7 +35,7 @@ export function installBrowser(
   }
 
   const backgroundInstall = async () => {
-    const binaryPath = paths.getBinaryPath(pkg, path.resolve(__dirname, '../../chromium'));
+    const binaryPath = paths.getBinaryPath(pkg, chromiumPath);
     const binaryChecksum = await sha256(binaryPath).catch(() => '');
 
     if (binaryChecksum !== pkg.binaryChecksum) {


### PR DESCRIPTION
## Summary

Took a look at the test failures from https://github.com/elastic/kibana/pull/189326, the most recent failure pointed out that the executable for linux was being requested from the wrong path, see image below; 

<img width="1229" alt="Screenshot 2024-08-12 at 09 28 47" src="https://github.com/user-attachments/assets/c14606ce-9958-411c-803c-89de2573db3a">


I ran this fix, in https://buildkite.com/elastic/kibana-pull-request/builds/226872#0191380a-3ff3-49cb-ae34-73ee20eac596 and all tests pass besides the checks for console.log I had included to debug the value of the binary path in the eventuality of a failure which didn't happen.

<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->