### PR TITLE
[Dashboards] POC  Migrate openLazyFlyout to the new flyout service

### DIFF
--- a/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/system_flyout_service.tsx
@@ -74,6 +74,7 @@ export class SystemFlyoutService {
           flyoutRef.close();
         };
 
+        // this
         // Render the flyout content using EuiFlyout with session="start"
         // This ensures full EUI Flyout System integration as a new MAIN flyout.
         render(

--- a/src/core/packages/overlays/browser/src/flyout.ts
+++ b/src/core/packages/overlays/browser/src/flyout.ts
@@ -46,5 +46,5 @@ export type OverlayFlyoutOpenOptions = Omit<
   /**
    * @deprecated Use `resizable` instead.
    */
-  isResizable?: boolean;
+  resizable?: boolean;
 };

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import type { CoreStart, OverlayFlyoutOpenOptions } from '@kbn/core/public';
+import type { CoreStart } from '@kbn/core/public';
+import type { OverlaySystemFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import { htmlIdGenerator } from '@elastic/eui';
-import { toMountPoint } from '@kbn/react-kibana-mount';
 import useAsync from 'react-use/lib/useAsync';
 import { i18n } from '@kbn/i18n';
 import { skip, take } from 'rxjs';
@@ -28,7 +28,10 @@ interface OpenLazyFlyoutParams {
   core: CoreStart;
   parentApi?: unknown;
   loadContent: (args: LoadContentArgs) => Promise<JSX.Element | null | void>;
-  flyoutProps?: Partial<OverlayFlyoutOpenOptions> & { triggerId?: string; focusedPanelId?: string };
+  flyoutProps?: Partial<OverlaySystemFlyoutOpenOptions> & {
+    triggerId?: string;
+    focusedPanelId?: string;
+  };
 }
 
 /**
@@ -74,34 +77,6 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
     onClose();
   });
 
-  //   const flyoutRef = core.overlays.openFlyout(
-  //     toMountPoint(
-  //       <LazyFlyout
-  //         closeFlyout={onClose}
-  //         loadContent={loadContent}
-  //         core={core}
-  //         ariaLabelledBy={ariaLabelledBy}
-  //       />,
-  //       core
-  //     ),
-  //     {
-  //       size: 500,
-  //       type: 'push',
-  //       paddingSize: 'm',
-  //       maxWidth: 800,
-  //       ownFocus: true,
-  //       isResizable: true,
-  //       outsideClickCloses: true,
-  //       className: 'kbnPresentationLazyFlyout',
-  //       'aria-labelledby': ariaLabelledBy,
-  //       onClose,
-  //       ...flyoutProps,
-  //     }
-  //   );
-  //   overlayTracker?.openOverlay(flyoutRef, { focusedPanelId });
-  //   return flyoutRef;
-  // };
-
   const flyoutRef = core.overlays.openSystemFlyout(
     <LazyFlyout
       closeFlyout={onClose}
@@ -115,13 +90,13 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
       type: 'push',
       paddingSize: 'm',
       maxWidth: 800,
+      resizable: true,
       ownFocus: true,
-      isResizable: true,
       outsideClickCloses: true,
       className: 'kbnPresentationLazyFlyout',
       'aria-labelledby': ariaLabelledBy,
-      'aria-label': 'Test title',
       onClose,
+      title: 'title placeholder',
       ...flyoutProps,
     }
   );

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -49,7 +49,7 @@ interface OpenLazyFlyoutParams {
  * @param params.loadContent - Async function that loads the flyout content. Must return a valid React element.
  *                             If it resolves to `null` or `undefined`, the flyout will close automatically.
  * @param params.flyoutProps - Optional props passed to `openFlyout` (e.g. size, className, etc).
- *                             Supports `OverlayFlyoutOpenOptions`.
+ *                             Supports `OverlaySystemFlyoutOpenOptions`.
  * @param params.parentApi - Optional parent API to track opened overlays (e.g. dashboardsApi).
  *
  * @returns A handle to the opened flyout (`OverlayRef`).

--- a/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
+++ b/src/platform/packages/shared/presentation/presentation_util/src/open_lazy_flyout.tsx
@@ -74,17 +74,43 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
     onClose();
   });
 
-  const flyoutRef = core.overlays.openFlyout(
-    toMountPoint(
-      <LazyFlyout
-        closeFlyout={onClose}
-        loadContent={loadContent}
-        core={core}
-        ariaLabelledBy={ariaLabelledBy}
-      />,
-      core
-    ),
+  //   const flyoutRef = core.overlays.openFlyout(
+  //     toMountPoint(
+  //       <LazyFlyout
+  //         closeFlyout={onClose}
+  //         loadContent={loadContent}
+  //         core={core}
+  //         ariaLabelledBy={ariaLabelledBy}
+  //       />,
+  //       core
+  //     ),
+  //     {
+  //       size: 500,
+  //       type: 'push',
+  //       paddingSize: 'm',
+  //       maxWidth: 800,
+  //       ownFocus: true,
+  //       isResizable: true,
+  //       outsideClickCloses: true,
+  //       className: 'kbnPresentationLazyFlyout',
+  //       'aria-labelledby': ariaLabelledBy,
+  //       onClose,
+  //       ...flyoutProps,
+  //     }
+  //   );
+  //   overlayTracker?.openOverlay(flyoutRef, { focusedPanelId });
+  //   return flyoutRef;
+  // };
+
+  const flyoutRef = core.overlays.openSystemFlyout(
+    <LazyFlyout
+      closeFlyout={onClose}
+      loadContent={loadContent}
+      core={core}
+      ariaLabelledBy={ariaLabelledBy}
+    />,
     {
+      session: 'start',
       size: 500,
       type: 'push',
       paddingSize: 'm',
@@ -94,6 +120,7 @@ export const openLazyFlyout = (params: OpenLazyFlyoutParams) => {
       outsideClickCloses: true,
       className: 'kbnPresentationLazyFlyout',
       'aria-labelledby': ariaLabelledBy,
+      'aria-label': 'Test title',
       onClose,
       ...flyoutProps,
     }

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_menu/show_add_menu.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/add_menu/show_add_menu.tsx
@@ -104,6 +104,9 @@ export const AddMenu = ({ dashboardApi, anchorElement, coreServices }: AddMenuPr
       flyoutProps: {
         'data-test-subj': 'dashboardPanelSelectionFlyout',
         triggerId: 'dashboardAddTopNavButton',
+        title: i18n.translate('dashboard.solutionToolbar.addPanelFlyout.headingText', {
+          defaultMessage: 'Add panel',
+        }),
       },
     });
   }, [coreServices, dashboardApi]);

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -110,7 +110,7 @@ export class CreateESQLControlAction implements Action<Context> {
       },
       flyoutProps: {
         'data-test-subj': 'create_esql_control_flyout',
-        isResizable: true,
+        resizable: true,
         maxWidth: 800,
         triggerId: 'dashboard-controls-menu-button',
         // When queryString is present (i.e. flyout opened from the ES|QL editor),


### PR DESCRIPTION
Resolves #241020 I have branched off of from [this PR](https://github.com/elastic/kibana/pull/233806) .

### Flyout System Roadmap

The plan is to move all Kibana flyouts to the New System, meaning:
- Every flyout will have a `session prop`.
- All flyouts will have a consistent look and behaviour
- Users will be able to navigate back to previous flyouts when moving from one flyout to another.

Terms for clarity:
**New System** – EUI Flyout with a session prop.
**New Service** – `core.overlays.openSystemFlyout`, which provides access to the EUI Flyout with the session prop in non-React contexts. The current` core.overlays.openFlyout` method will eventually be deprecated. 

The summary of my research is in [this doc.](https://docs.google.com/document/d/1c0uz8_UnsfHs7CGmdnNisCjsHMtzqVeQSqPGwnps_vo/edit?tab=t.0)

### Session prop
In this PR I set `session: "start"` inside `openLazyFlyout`.
This ensures that every flyout opened through this helper starts a new session and is treated as the main flyout in the workflow.

`SystemFlyoutService` uses `session: "start"` as its default value, whereas [the documentation mentions](https://github.com/elastic/eui/issues/9158) `session: "inherit"` is the default. This happens in the EUI component because we don't want to change the behavior of existing flyouts that are rendered using the EUI React component directly. For flyouts that are rendered with `core.overlays.openSystemFlyout`, it is safe to assume the developer wants a system flyout, so we set session to "start" for those calls. More information in the summary in [this doc](https://docs.google.com/document/d/1c0uz8_UnsfHs7CGmdnNisCjsHMtzqVeQSqPGwnps_vo/edit?tab=t.0).

### Types
I also updated openLazyFlyout to use `OverlaySystemFlyoutOpenOptions`, which provides the correct types for the session property. Previously it was using `OverlayFlyoutOpenOptions`, where the session type was limited to "`never`", so the typing didn’t match the new flyout system.

### SystemFlyoutService
I updated openLazyFlyout to use the New Service – core.overlays.openSystemFlyout. This service gives access to the EUI Flyout with the session prop, even in non-React contexts

### How titles are rendered in the new flyout system
I also investigated how titles are rendered in the new flyout system.
Even though we pass a title via flyoutMenuProps.title, the title inside our flyouts is often nested deeper and doesn’t have its own dedicated header element.

This aligns with[ a known issue ](https://github.com/elastic/eui/issues/9148)in the new flyout system:
main flyouts currently render the title in the flyout menu bar, coming from flyoutMenuProps.title, even though [the design requires using the standard EuiFlyoutHeader title.
](https://www.figma.com/design/SvpfCqaZPb2iAYnPtd0Gnr/Kibana-UI?node-id=4565-11119&t=6wk86WAQM1SpQF6h-0)
This is the same bug reported in the EUI repository — title handling is still being refined, because the system currently places the title in the menu bar instead of the header.
I’m mentioning it here so we don’t spend additional time researching this during the POC.


### Responsiveness
I also tested how the flyouts behave on different mobile views and in various dashboard contexts.

### Flyouts for POC
In the POC, I decided to test the full path: Add → Add Panel Flyout → ES|QL Panel Flyout → Create Variable Control Flyout, in order to reproduce the session flow and see how the flyouts behave in sequence.
The video of their behaviour is shown below:

https://github.com/user-attachments/assets/271aa271-de7a-4911-be8d-5d25fcb8cba1






